### PR TITLE
- Separação do MOD11 da validação

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 /lib
 coverage
+.history/

--- a/src/__tests__/usevalidationsbr.spec.ts
+++ b/src/__tests__/usevalidationsbr.spec.ts
@@ -36,15 +36,14 @@ describe('UseValidationBr CNPJ', () => {
 });
 
 describe('UseValidationBr CPF', () => {
-  it('should be able return true to valid CNPJ', () => {
+  it('should be able return true to valid CPF', () => {
     expect.assertions(3);
-
     expect(useValidationsBR('cpf', '248.283.728-65')).toBe(true);
     expect(useValidationsBR('cpf', '241.845.620-00')).toBe(true);
     expect(useValidationsBR('cpf', '551.137.567-50')).toBe(true);
   });
 
-  it('should be able return false to invalid CNPJ', () => {
+  it('should be able return false to invalid CPF', () => {
     expect.assertions(2);
 
     expect(useValidationsBR('cpf', '248.283.728-66')).toBe(false);

--- a/src/__tests__/validateCPF.spec.ts
+++ b/src/__tests__/validateCPF.spec.ts
@@ -16,7 +16,6 @@ describe('Validate CPF', () => {
     expect(validateCPF('248.283.728-66')).toBe(false);
     expect(validateCPF('425.719.798-04')).toBe(false);
     expect(validateCPF('012.345.678-91')).toBe(false);
-
   });
 
   it('should be able return false to pass a empty string', () => {

--- a/src/__tests__/validateCPF.spec.ts
+++ b/src/__tests__/validateCPF.spec.ts
@@ -1,19 +1,22 @@
 import { validateCPF } from '../index';
 
-describe('Validate CNPJ', () => {
-  it('should be able return true to valid CNPJ', () => {
-    expect.assertions(3);
+describe('Validate CPF', () => {
+  it('should be able return true to valid CPF', () => {
+    expect.assertions(4);
 
+    expect(validateCPF('012.345.678-90')).toBe(true);
     expect(validateCPF('248.283.728-65')).toBe(true);
     expect(validateCPF('241.845.620-00')).toBe(true);
     expect(validateCPF('551.137.567-50')).toBe(true);
   });
 
-  it('should be able return false to invalid CNPJ', () => {
-    expect.assertions(2);
+  it('should be able return false to invalid CPF', () => {
+    expect.assertions(3);
 
     expect(validateCPF('248.283.728-66')).toBe(false);
     expect(validateCPF('425.719.798-04')).toBe(false);
+    expect(validateCPF('012.345.678-91')).toBe(false);
+
   });
 
   it('should be able return false to pass a empty string', () => {
@@ -22,5 +25,6 @@ describe('Validate CNPJ', () => {
 
   it('should be able return false to pass a only repeated numbers', () => {
     expect(validateCPF('000.000.000-00')).toBe(false);
+    expect(validateCPF('111.111.111-11')).toBe(false);
   });
 });

--- a/src/validations/mod11.ts
+++ b/src/validations/mod11.ts
@@ -10,17 +10,14 @@ export const mod11: (v: string, l?: number) => number = (
   clearValue: string,
   limite?: number,
 ) => {
-const valor = String(clearValue).replace(/\D/g, '');
-let sum = 0;
-let mult = 2;
+  const valor = String(clearValue).replace(/\D/g, '');
+  let sum = 0;
+  let mult = 2;
 
-    for(let i = valor.length-1; i >= 0; i-- ) {
-        sum += (
-            mult * (+valor[i])
-        );
-      if(++mult > (limite || valor.length - 1)) mult = 2;
-    }
-    const dv = ((sum * 10) % 11) % 10;
-    return dv;
+  for (let i = valor.length - 1; i >= 0; i--) {
+    sum += mult * +valor[i];
+    if (++mult > (limite || valor.length - 1)) mult = 2;
+  }
+  const dv = ((sum * 10) % 11) % 10;
+  return dv;
 };
-  

--- a/src/validations/mod11.ts
+++ b/src/validations/mod11.ts
@@ -1,0 +1,26 @@
+/**
+ * Calcula o MOD11 para o número informado
+ * @param valor Número base para o calculo
+ * @param limite Limite da casa de multiplicação
+ * Para CPF assume o valor de 12, para CNPJ o valor de 9. Caso não informado,
+ * assume que o limite é o tamanho(string.length) do valor informado
+ * @returns Retorna o DV calculado
+ */
+export const mod11: (v: string, l?: number) => number = (
+  clearValue: string,
+  limite?: number,
+) => {
+const valor = String(clearValue).replace(/\D/g, '');
+let sum = 0;
+let mult = 2;
+
+    for(let i = valor.length-1; i >= 0; i-- ) {
+        sum += (
+            mult * (+valor[i])
+        );
+      if(++mult > (limite || valor.length - 1)) mult = 2;
+    }
+    const dv = ((sum * 10) % 11) % 10;
+    return dv;
+};
+  

--- a/src/validations/mod11.ts
+++ b/src/validations/mod11.ts
@@ -2,13 +2,12 @@
  * Calcula o MOD11 para o número informado
  * @param valor Número base para o calculo
  * @param limite Limite da casa de multiplicação
- * Para CPF assume o valor de 12, para CNPJ o valor de 9. Caso não informado,
- * assume que o limite é o tamanho(string.length) do valor informado
+ * Para CPF assume o valor de 12, para CNPJ o valor de 9.
  * @returns Retorna o DV calculado
  */
-export const mod11: (v: string, l?: number) => number = (
+export const mod11: (v: string, l: number) => number = (
   clearValue: string,
-  limite?: number,
+  limite: number,
 ) => {
   const valor = String(clearValue).replace(/\D/g, '');
   let sum = 0;
@@ -16,7 +15,9 @@ export const mod11: (v: string, l?: number) => number = (
 
   for (let i = valor.length - 1; i >= 0; i--) {
     sum += mult * +valor[i];
-    if (++mult > (limite || valor.length - 1)) mult = 2;
+    if (++mult > limite){
+      mult = 2
+    };
   }
   const dv = ((sum * 10) % 11) % 10;
   return dv;

--- a/src/validations/mod11.ts
+++ b/src/validations/mod11.ts
@@ -15,9 +15,9 @@ export const mod11: (v: string, l: number) => number = (
 
   for (let i = valor.length - 1; i >= 0; i--) {
     sum += mult * +valor[i];
-    if (++mult > limite){
-      mult = 2
-    };
+    if (++mult > limite) {
+      mult = 2;
+    }
   }
   const dv = ((sum * 10) % 11) % 10;
   return dv;

--- a/src/validations/validateCNPJ.ts
+++ b/src/validations/validateCNPJ.ts
@@ -1,10 +1,18 @@
+import { mod11 } from './mod11';
+
+/**
+ * Valida o CNPJ. A entrada pode ser com ou sem máscaras.
+ * O tamanho deve ser respeitado como em '00.000.000/0000-00' ou '00000000000000'.
+ * @param value 
+ * @returns True se o CNPJ é válido, falso caso contrário
+ */
 export function validateCNPJ(value: string): boolean {
   const clearValue = String(value).replace(/[^\d]+/g, '');
-
+  // Campo sem máscara 
   if (clearValue === '') return false;
-
+  // Tamanho diferente do exigido
   if (clearValue.length !== 14) return false;
-
+  // Valores carteados já conhecidos como inválidos
   if (
     clearValue === '00000000000000' ||
     clearValue === '11111111111111' ||
@@ -16,39 +24,13 @@ export function validateCNPJ(value: string): boolean {
     clearValue === '77777777777777' ||
     clearValue === '88888888888888' ||
     clearValue === '99999999999999'
-  )
+  ){
     return false;
-
-  let length = clearValue.length - 2;
-  let numbers = clearValue.substring(0, length);
-  const digits = clearValue.substring(length);
-  let sum = 0;
-  let position = length - 7;
-
-  for (let i = length; i >= 1; i -= 1) {
-    sum += +numbers.charAt(length - i) * position;
-    position -= 1;
-    if (position < 2) position = 9;
   }
-
-  let result = sum % 11 < 2 ? 0 : 11 - (sum % 11);
-
-  if (result !== +digits.charAt(0)) return false;
-
-  length += 1;
-  numbers = clearValue.substring(0, length);
-  sum = 0;
-  position = length - 7;
-
-  for (let i = length; i >= 1; i -= 1) {
-    sum += +numbers.charAt(length - i) * position;
-    position -= 1;
-    if (position < 2) position = 9;
-  }
-
-  result = sum % 11 < 2 ? 0 : 11 - (sum % 11);
-
-  if (result !== +digits.charAt(1)) return false;
-
-  return true;
+  // O CNPJ possui 2 DVs, excluíndo para validar
+  const valWithoutDvs = clearValue.substring(0, clearValue.length-2);
+  const dv1 = mod11(valWithoutDvs, 9);  
+  const dv2 = mod11(valWithoutDvs + dv1, 9);  
+  // Compara com a informação passada como paramêtro
+  return (valWithoutDvs + dv1 + dv2) === clearValue;
 }

--- a/src/validations/validateCNPJ.ts
+++ b/src/validations/validateCNPJ.ts
@@ -3,12 +3,12 @@ import { mod11 } from './mod11';
 /**
  * Valida o CNPJ. A entrada pode ser com ou sem máscaras.
  * O tamanho deve ser respeitado como em '00.000.000/0000-00' ou '00000000000000'.
- * @param value 
+ * @param value
  * @returns True se o CNPJ é válido, falso caso contrário
  */
 export function validateCNPJ(value: string): boolean {
   const clearValue = String(value).replace(/[^\d]+/g, '');
-  // Campo sem máscara 
+  // Campo sem máscara
   if (clearValue === '') return false;
   // Tamanho diferente do exigido
   if (clearValue.length !== 14) return false;
@@ -24,13 +24,13 @@ export function validateCNPJ(value: string): boolean {
     clearValue === '77777777777777' ||
     clearValue === '88888888888888' ||
     clearValue === '99999999999999'
-  ){
+  ) {
     return false;
   }
   // O CNPJ possui 2 DVs, excluíndo para validar
-  const valWithoutDvs = clearValue.substring(0, clearValue.length-2);
-  const dv1 = mod11(valWithoutDvs, 9);  
-  const dv2 = mod11(valWithoutDvs + dv1, 9);  
+  const valWithoutDvs = clearValue.substring(0, clearValue.length - 2);
+  const dv1 = mod11(valWithoutDvs, 9);
+  const dv2 = mod11(valWithoutDvs + dv1, 9);
   // Compara com a informação passada como paramêtro
-  return (valWithoutDvs + dv1 + dv2) === clearValue;
+  return valWithoutDvs + dv1 + dv2 === clearValue;
 }

--- a/src/validations/validateCPF.ts
+++ b/src/validations/validateCPF.ts
@@ -3,34 +3,29 @@ import { mod11 } from './mod11';
 /**
  * Função que valida se a string é apenas
  * números repetidos.
- * 
+ *
  * @param ref String númerica
- * @returns True se for contida por apenas caracteres repetidos, 
+ * @returns True se for contida por apenas caracteres repetidos,
  * false caso contrário
  */
 const isRepeated = (ref: string) => {
-  const ret = ref.replace(
-    new RegExp(
-      ref[0], 
-      'g'
-    ), ''
-  ).trim().length === 0;
+  const ret = ref.replace(new RegExp(ref[0], 'g'), '').trim().length === 0;
   return ret;
-}
+};
 /**
  * Valida o CPF. A entrada pode ser com ou sem máscaras.
  * O tamanho deve ser respeitado como em '000.000.000-00' ou '00000000000'.
- * @param value 
+ * @param value
  */
 export function validateCPF(value: string): boolean {
-  // Campo sem máscara 
+  // Campo sem máscara
   const clearValue = String(value).replace(/\D/g, '');
   // O CPF possui 2 DVs, excluíndo para validar
-  const valWithoutDvs = clearValue.substring(0, clearValue.length-2);
-  let sum = 0;
+  const valWithoutDvs = clearValue.substring(0, clearValue.length - 2);
+  const sum = 0;
   let rest;
   // Valida se está vazio ou é valor repetido
-  if (!clearValue || isRepeated(clearValue) ){ 
+  if (!clearValue || isRepeated(clearValue)) {
     return false;
   }
   // Calcula o primeiro DV
@@ -38,5 +33,5 @@ export function validateCPF(value: string): boolean {
   // Calcula o segundo DV2
   const dv2 = mod11(valWithoutDvs + dv1, 12);
   // Compara com a informação passada como paramêtro
-  return (valWithoutDvs + dv1 + dv2) === clearValue;
+  return valWithoutDvs + dv1 + dv2 === clearValue;
 }

--- a/src/validations/validateCPF.ts
+++ b/src/validations/validateCPF.ts
@@ -1,31 +1,42 @@
+import { mod11 } from './mod11';
+
+/**
+ * Função que valida se a string é apenas
+ * números repetidos.
+ * 
+ * @param ref String númerica
+ * @returns True se for contida por apenas caracteres repetidos, 
+ * false caso contrário
+ */
+const isRepeated = (ref: string) => {
+  const ret = ref.replace(
+    new RegExp(
+      ref[0], 
+      'g'
+    ), ''
+  ).trim().length === 0;
+  return ret;
+}
+/**
+ * Valida o CPF. A entrada pode ser com ou sem máscaras.
+ * O tamanho deve ser respeitado como em '000.000.000-00' ou '00000000000'.
+ * @param value 
+ */
 export function validateCPF(value: string): boolean {
+  // Campo sem máscara 
   const clearValue = String(value).replace(/\D/g, '');
+  // O CPF possui 2 DVs, excluíndo para validar
+  const valWithoutDvs = clearValue.substring(0, clearValue.length-2);
   let sum = 0;
   let rest;
-
-  if (clearValue === '') return false;
-
-  if (clearValue === '00000000000') return false;
-
-  for (let i = 1; i <= 9; i += 1)
-    sum += +clearValue.substring(i - 1, i) * (11 - i);
-
-  rest = (sum * 10) % 11;
-
-  if (rest === 10 || rest === 11) rest = 0;
-
-  if (rest !== +clearValue.substring(9, 10)) return false;
-
-  sum = 0;
-
-  for (let i = 1; i <= 10; i += 1)
-    sum += +clearValue.substring(i - 1, i) * (12 - i);
-
-  rest = (sum * 10) % 11;
-
-  if (rest === 10 || rest === 11) rest = 0;
-
-  if (rest !== +clearValue.substring(10, 11)) return false;
-
-  return true;
+  // Valida se está vazio ou é valor repetido
+  if (!clearValue || isRepeated(clearValue) ){ 
+    return false;
+  }
+  // Calcula o primeiro DV
+  const dv1 = mod11(valWithoutDvs, 12);
+  // Calcula o segundo DV2
+  const dv2 = mod11(valWithoutDvs + dv1, 12);
+  // Compara com a informação passada como paramêtro
+  return (valWithoutDvs + dv1 + dv2) === clearValue;
 }

--- a/src/validations/validateCPF.ts
+++ b/src/validations/validateCPF.ts
@@ -22,8 +22,6 @@ export function validateCPF(value: string): boolean {
   const clearValue = String(value).replace(/\D/g, '');
   // O CPF possui 2 DVs, excluíndo para validar
   const valWithoutDvs = clearValue.substring(0, clearValue.length - 2);
-  const sum = 0;
-  let rest;
   // Valida se está vazio ou é valor repetido
   if (!clearValue || isRepeated(clearValue)) {
     return false;


### PR DESCRIPTION
- Foi feita uma pequena correção nos labels dos testes para CPF que indicavam CNPJ.
- O calculo do MOD11 foi desacoplado da validação e é reutilizado em CPF e CNPJ. A função de cálculo do **MOD11** NÃO foi exposta, já que o objetivo é validar. 
- Uma discreta documentação foi adicionada às validações de CPF e CNPJ
- Foi adicionada a rotina de validação de número repetido no CPF

