### PR TITLE
Altera a regex de validação do CEP

### DIFF
--- a/src/validations/validateCep.ts
+++ b/src/validations/validateCep.ts
@@ -1,5 +1,5 @@
 export const validateCep = (() => {
-  const regex = /^\d{5}-\d{3}$/;
+  const regex = /^([\d]{8}|[\d]{5}-[\d]{3})$/;
 
   return (cep: string) => typeof cep === 'string' && regex.test(cep);
 })();


### PR DESCRIPTION
Altera a regex de validação do CEP para validar o valor com ou sem o caractere de traço ( - ) na string.