### PR TITLE
Altera validação de e-mail para domínios maiores (.digital, por exemplo)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,12 @@
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx ./src",
     "test": "jest",
-    "prepare": "npm run build && husky install",
+    "prepare": "husky install",
     "prepublishOnly": "npm test && npm run lint",
     "preversion": "npm run lint",
     "version": "npm run format && git add -A src",
-    "postversion": "git push && git push --tags"
+    "postversion": "git push && git push --tags",
+    "prepublish": "npm run build"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",

--- a/package.json
+++ b/package.json
@@ -21,12 +21,11 @@
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx ./src",
     "test": "jest",
-    "prepare": "husky install",
+    "prepare": "npm run build && husky install",
     "prepublishOnly": "npm test && npm run lint",
     "preversion": "npm run lint",
     "version": "npm run format && git add -A src",
-    "postversion": "git push && git push --tags",
-    "prepublish": "npm run build"
+    "postversion": "git push && git push --tags"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",

--- a/src/__tests__/validateEmail.spec.ts
+++ b/src/__tests__/validateEmail.spec.ts
@@ -5,6 +5,10 @@ describe('Validate Email', () => {
     expect(validateEmail('johndoe@email.com')).toBe(true);
   });
 
+  it('should be able return true to valid Email with custom domain', () => {
+    expect(validateEmail('johndoe@email.digital')).toBe(true);
+  });
+
   it('should be able return false to invalid Email', () => {
     expect(validateEmail('johndoe.email.com')).toBe(false);
   });

--- a/src/validations/validateEmail.ts
+++ b/src/validations/validateEmail.ts
@@ -1,5 +1,5 @@
 export function validateEmail(value: string): boolean {
-  const regex = /^[\w!#$%&'*+/=?`{|}~^-]+(?:\.[\w!#$%&'*+/=?`{|}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}$/i;
+  const regex = /^[\w!#$%&'*+/=?`{|}~^-]+(?:\.[\w!#$%&'*+/=?`{|}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,10}$/i;
   const email = value;
   if (regex.test(email)) {
     return Boolean(email);


### PR DESCRIPTION
A validação de e-mail não estava funcionando para domínios no formato dominio.digital. Ajustei a validação e adicionei um teste para esse cenário