### PR TITLE
fix: change GO ie to works with new format

### DIFF
--- a/src/__tests__/validateIE.spec.ts
+++ b/src/__tests__/validateIE.spec.ts
@@ -30,6 +30,7 @@ describe('Validate Email', () => {
   });
   it('should be able return true to valid GO IE', () => {
     expect(validateIE('11.223.711-8', 'go')).toBe(true);
+    expect(validateIE('20.002.703-4', 'go')).toBe(true);
   });
   it('should be able return true to valid MA IE', () => {
     expect(validateIE('12351768-0', 'ma')).toBe(true);

--- a/src/validations/ie/states/go.ts
+++ b/src/validations/ie/states/go.ts
@@ -5,7 +5,7 @@ export function validateGO(ie: string): boolean {
 
   if (length !== 9) return false;
 
-  const beginRegex = /^(1[015]|2[0-9])/;
+  const beginRegex = /^(1[01]|2[0-9])/;
   const begin = ieStr.substr(0, 2);
   if (!beginRegex.test(begin)) return false;
 

--- a/src/validations/ie/states/go.ts
+++ b/src/validations/ie/states/go.ts
@@ -5,9 +5,9 @@ export function validateGO(ie: string): boolean {
 
   if (length !== 9) return false;
 
-  const beginWith = ['10', '11', '15'];
+  const beginRegex = /^(1[015]|2[0-9])/;
   const begin = ieStr.substr(0, 2);
-  if (!(beginWith.indexOf(begin) >= 0)) return false;
+  if (!beginRegex.test(begin)) return false;
 
   const position = length - 1;
   let weight = length;


### PR DESCRIPTION
O novo formato aceita os números de 20 a 29 no inicio do CCE.

https://www.sintegra.gov.br/Cad_Estados/cad_GO.html